### PR TITLE
[WIP] Memory Source (with MemorySource Singleton)

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/ListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/util/ListenerBus.scala
@@ -102,6 +102,7 @@ private[spark] trait ListenerBus[L <: AnyRef, E] extends Logging {
     // CollectionConverters can create a JIterableWrapper if we use asScala.
     // However, this method will be called frequently. To avoid the wrapper cost, here we use
     // Java Iterator directly.
+
     val iter = listenersPlusTimers.iterator
     while (iter.hasNext) {
       val listenerAndMaybeTimer = iter.next()

--- a/core/src/main/scala/org/apache/spark/util/SingleColumnConsoleTableBuilder.scala
+++ b/core/src/main/scala/org/apache/spark/util/SingleColumnConsoleTableBuilder.scala
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util
+import java.util.Locale
+
+private case class TableSection(header: String) {
+  var rows: Seq[String] = Seq.empty
+
+  def addRow(row: String): Unit = {
+    rows = rows :+ row
+  }
+}
+
+class SingleColumnConsoleTableBuilder(title: String) {
+   private var sections: Seq[TableSection] = Seq.empty
+
+  def addHeader(header: String): SingleColumnConsoleTableBuilder = {
+    sections = sections :+ TableSection(header)
+    this
+  }
+
+  def addRows(rows: String*): SingleColumnConsoleTableBuilder = {
+      rows.foreach(row => sections.last.addRow(row))
+      this
+  }
+
+  def print(): Unit = {
+    val padding = 2 + 2 // 2 spaces on either side
+
+    // Determine the max-width so that we can center
+    val width = (sections.flatMap { sections =>
+        sections.header +: sections.rows
+    } :+ title).map(_.length).max + padding
+
+    // scalastyle:off println
+    printTitle(title, width)
+
+    sections.foreach { section =>
+      // Print the section header
+      printSeparatorRow(width)
+      printTextRow(section.header.toUpperCase(Locale.ROOT), width, center = true)
+      printSeparatorRow(width)
+
+      // Print each row
+      section.rows.foreach { row =>
+        printTextRow(row, width, center = false)
+      }
+    }
+
+    printSeparatorRow(width)
+    // scalastyle:on println
+  }
+
+  private def printTitle(title: String, width: Int): Unit = {
+    // scalastyle:off println
+    val leftPadding = (width - title.length) / 2
+    val rightPadding = width - title.length - leftPadding
+
+    // Print a box around the title
+    println(s"+${"=" * width}+")
+    println(s"|${" " * leftPadding}$title${" " * rightPadding}|")
+    println(s"+${"=" * width}+")
+    // scalastyle:on println
+  }
+
+
+  private def printSeparatorRow(width: Int): Unit = {
+    // scalastyle:off println
+    println(s"|${"-" * width}|")
+    // scalastyle:on println
+  }
+
+  private def printTextRow(text: String, width: Int, center: Boolean): Unit = {
+    // Assume non-centered text
+    var leftPadding = 2
+    var rightPadding = width - text.length - leftPadding
+
+    if (center) {
+      val hasImbalancedSides = (width - text.length) % 2 != 0
+      leftPadding = (width - text.length) / 2
+
+      val extraRightPadding = if (hasImbalancedSides) 1 else 0
+      rightPadding = leftPadding + extraRightPadding
+    }
+
+    // scalastyle:off println
+    println(s"|${" " * leftPadding}$text${" " * rightPadding}|")
+    // scalastyle:on println
+  }
+}

--- a/sql/core/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/sql/core/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -24,6 +24,7 @@ org.apache.spark.sql.execution.datasources.v2.parquet.ParquetDataSourceV2
 org.apache.spark.sql.execution.datasources.v2.text.TextDataSourceV2
 org.apache.spark.sql.execution.datasources.xml.XmlFileFormat
 org.apache.spark.sql.execution.streaming.ConsoleSinkProvider
+org.apache.spark.sql.execution.streaming.SpySinkProvider
 org.apache.spark.sql.execution.streaming.sources.MemorySourceProvider
 org.apache.spark.sql.execution.streaming.sources.RateStreamProvider
 org.apache.spark.sql.execution.streaming.sources.TextSocketSourceProvider

--- a/sql/core/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/sql/core/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -24,6 +24,7 @@ org.apache.spark.sql.execution.datasources.v2.parquet.ParquetDataSourceV2
 org.apache.spark.sql.execution.datasources.v2.text.TextDataSourceV2
 org.apache.spark.sql.execution.datasources.xml.XmlFileFormat
 org.apache.spark.sql.execution.streaming.ConsoleSinkProvider
+org.apache.spark.sql.execution.streaming.sources.MemorySourceProvider
 org.apache.spark.sql.execution.streaming.sources.RateStreamProvider
 org.apache.spark.sql.execution.streaming.sources.TextSocketSourceProvider
 org.apache.spark.sql.execution.datasources.binaryfile.BinaryFileFormat

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/SpySink.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/SpySink.scala
@@ -1,5 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.sql.execution.streaming
 
-class SpySink {
+import java.util
 
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql._
+import org.apache.spark.sql.connector.catalog.{SupportsWrite, Table, TableCapability}
+import org.apache.spark.sql.connector.write.{LogicalWriteInfo, PhysicalWriteInfo, SupportsTruncate, Write, WriteBuilder, WriterCommitMessage}
+import org.apache.spark.sql.connector.write.streaming.{StreamingDataWriterFactory, StreamingWrite}
+import org.apache.spark.sql.execution.streaming.sources.PackedRowWriterFactory
+import org.apache.spark.sql.internal.connector.{SimpleTableProvider, SupportsStreamingUpdateAsAppend}
+import org.apache.spark.sql.sources.{BaseRelation, CreatableRelationProvider, DataSourceRegister}
+import org.apache.spark.sql.streaming.StreamingQueryListener
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+case class SpyRelation(override val sqlContext: SQLContext)
+  extends BaseRelation {
+  override def schema: StructType = StructType(Nil)
 }
+
+class SpySinkProvider extends SimpleTableProvider
+  with DataSourceRegister
+  with CreatableRelationProvider {
+
+  override def getTable(options: CaseInsensitiveStringMap): Table = {
+    new SpyTable
+  }
+
+  def createRelation(
+      sqlContext: SQLContext,
+      mode: SaveMode,
+      parameters: Map[String, String],
+      data: DataFrame): BaseRelation = {
+    SpyRelation(sqlContext)
+  }
+
+  def shortName(): String = "spy"
+}
+
+class SpyTable() extends Table with SupportsWrite {
+  override def name(): String = "spy"
+
+  override def schema(): StructType = StructType(Nil)
+
+  override def capabilities(): util.Set[TableCapability] = {
+    util.EnumSet.of(TableCapability.STREAMING_WRITE)
+  }
+
+  override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {
+    new WriteBuilder with SupportsTruncate with SupportsStreamingUpdateAsAppend {
+      private val inputSchema: StructType = info.schema()
+
+      // Do nothing for truncate. Spy sink is special and it just prints all the records.
+      override def truncate(): WriteBuilder = this
+
+      override def build(): Write = {
+        new Write {
+          override def toStreaming: StreamingWrite = {
+            assert(inputSchema != null)
+            new SpyWriter()
+          }
+        }
+      }
+    }
+  }
+}
+
+// SpyWriter is initialized with a reference to an array of messages
+// owned by its caller Table. This is because the driver has access
+// only to the Table, and it needs to be able to access the messages
+// so that it can print them when the StreamingQueryProgress becomes
+// available.
+private class SpyWriter()
+  extends StreamingWrite with Logging {
+  assert(SparkSession.getActiveSession.isDefined)
+
+  // Register a streaming query listener
+  val spark = SparkSession.getDefaultSession.get
+
+//  SpyWriter.initializeListener(spark)
+  // scalastyle:off println
+  println(s"Adding listener for current spark session ${spark}")
+
+  spark.streams.addListener(new StreamingQueryListener() {
+    override def onQueryStarted(event: StreamingQueryListener.QueryStartedEvent): Unit = {
+      println("From Spy query started!")
+    }
+    override def onQueryProgress(event: StreamingQueryListener.QueryProgressEvent): Unit = {
+      println(s"From Spy query made progress: ${event.progress}")
+    }
+    override def onQueryTerminated(event: StreamingQueryListener.QueryTerminatedEvent): Unit = {
+      println("From Spy query terminated!")
+    }
+  })
+
+  override def useCommitCoordinator(): Boolean = false
+
+  override def commit(epochId: Long, messages: Array[WriterCommitMessage]): Unit = {
+    // scalastyle:off println
+    println(s"Called commit for epoch $epochId with num messages ${messages.length}")
+  }
+
+  def abort(epochId: Long, messages: Array[WriterCommitMessage]): Unit = {}
+
+  override def toString(): String = {
+    s"SpyWriter"
+  }
+
+  override def createStreamingWriterFactory(
+      info: PhysicalWriteInfo)
+      : StreamingDataWriterFactory = PackedRowWriterFactory
+}
+
+object SpyWriter {
+  println("SpyWriter object created!")
+}
+

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/SpySink.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/SpySink.scala
@@ -19,17 +19,22 @@ package org.apache.spark.sql.execution.streaming
 
 import java.util
 
+import scala.collection.immutable
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.catalog.{SupportsWrite, Table, TableCapability}
 import org.apache.spark.sql.connector.write.{LogicalWriteInfo, PhysicalWriteInfo, SupportsTruncate, Write, WriteBuilder, WriterCommitMessage}
 import org.apache.spark.sql.connector.write.streaming.{StreamingDataWriterFactory, StreamingWrite}
-import org.apache.spark.sql.execution.streaming.sources.PackedRowWriterFactory
+import org.apache.spark.sql.execution.streaming.sources.{PackedRowCommitMessage, PackedRowWriterFactory}
 import org.apache.spark.sql.internal.connector.{SimpleTableProvider, SupportsStreamingUpdateAsAppend}
 import org.apache.spark.sql.sources.{BaseRelation, CreatableRelationProvider, DataSourceRegister}
 import org.apache.spark.sql.streaming.StreamingQueryListener
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.util.SingleColumnConsoleTableBuilder
+
 
 case class SpyRelation(override val sqlContext: SQLContext)
   extends BaseRelation {
@@ -75,7 +80,7 @@ class SpyTable() extends Table with SupportsWrite {
         new Write {
           override def toStreaming: StreamingWrite = {
             assert(inputSchema != null)
-            new SpyWriter()
+            new SpyWriter(info.queryId())
           }
         }
       }
@@ -83,39 +88,35 @@ class SpyTable() extends Table with SupportsWrite {
   }
 }
 
-// SpyWriter is initialized with a reference to an array of messages
-// owned by its caller Table. This is because the driver has access
-// only to the Table, and it needs to be able to access the messages
-// so that it can print them when the StreamingQueryProgress becomes
-// available.
-private class SpyWriter()
+// SpyWriter is a streaming writer that writer that spies on the query progress
+// and prints it out along with the written data.
+private class SpyWriter(queryId: String)
   extends StreamingWrite with Logging {
   assert(SparkSession.getActiveSession.isDefined)
 
-  // Register a streaming query listener
+  // TODO(neil): Figure out why the activeSession doesn't work
   val spark = SparkSession.getDefaultSession.get
 
-//  SpyWriter.initializeListener(spark)
-  // scalastyle:off println
-  println(s"Adding listener for current spark session ${spark}")
-
-  spark.streams.addListener(new StreamingQueryListener() {
-    override def onQueryStarted(event: StreamingQueryListener.QueryStartedEvent): Unit = {
-      println("From Spy query started!")
-    }
-    override def onQueryProgress(event: StreamingQueryListener.QueryProgressEvent): Unit = {
-      println(s"From Spy query made progress: ${event.progress}")
-    }
-    override def onQueryTerminated(event: StreamingQueryListener.QueryTerminatedEvent): Unit = {
-      println("From Spy query terminated!")
-    }
-  })
+  SpyWriter.registerListener(spark, queryId)
 
   override def useCommitCoordinator(): Boolean = false
 
+  // Commit is called _before_ the streaming query makes progress, which happens at
+  // the end of the batch. As a result, we need to store the messages for this epochId
+  // until the associated streaming query progress comes along, at which point we
+  // print (and evict) those messages.
   override def commit(epochId: Long, messages: Array[WriterCommitMessage]): Unit = {
-    // scalastyle:off println
-    println(s"Called commit for epoch $epochId with num messages ${messages.length}")
+    // scalastyle:off
+    println(s"Commiting for epoch ${epochId} with num messages ${messages.length}")
+
+    val rows = messages.collect {
+      case PackedRowCommitMessage(rs) => rs
+    }.flatten
+
+    // Print out every row
+    rows.foreach(println)
+
+    SpyWriter.registerMessages(queryId, epochId, rows)
   }
 
   def abort(epochId: Long, messages: Array[WriterCommitMessage]): Unit = {}
@@ -130,6 +131,94 @@ private class SpyWriter()
 }
 
 object SpyWriter {
+  // Keeps track of all the queryIds that currently have Spy listeners.
+  // TODO(neil): Check why SpyWriter seems to be initialized multiple times
+  //  per batch.
+  private val activeQueryIds = scala.collection.mutable.Set[String]()
+
+  // Store the messages for each batch, for each query (the data from each batch is
+  // copied here during SpyTable::commit. We store the mesages per batch so that
+  // we can print them out when we receive the streaming query progress.
+  private val messagesPerEpoch = scala.collection.mutable.Map[String,
+    scala.collection.mutable.Map[Long, Array[InternalRow]]]()
+
+  private def registerListener(spark: SparkSession, queryId: String): Unit = {
+    var listenerExists = false
+
+    activeQueryIds.synchronized {
+      if (activeQueryIds.contains(queryId)) {
+        listenerExists = true
+      } else {
+        activeQueryIds += queryId
+      }
+    }
+
+    if (listenerExists) {
+      return
+    }
+
+    // scalastyle:off println
+    spark.streams.addListener(new StreamingQueryListener() {
+      override def onQueryStarted(event: StreamingQueryListener.QueryStartedEvent): Unit = {
+        println("From Spy query started!")
+      }
+      override def onQueryProgress(event: StreamingQueryListener.QueryProgressEvent): Unit = {
+        println(s"[ON PROGRESS] For queryId ${queryId} and batchId ${event.progress.batchId}")
+
+        val messages = messagesPerEpoch.synchronized {
+          messagesPerEpoch(queryId)(event.progress.batchId)
+        }
+
+        val batchId = event.progress.batchId
+        var table = new SingleColumnConsoleTableBuilder(s"Batch ${batchId} Progress")
+
+        table = table
+          .addHeader("WRITES TO SINK")
+          .addRows(immutable.ArraySeq.unsafeWrapArray(messages.map(_.toString)): _*)
+
+        // Only print the watermark if there is one
+        if (event.progress.eventTime.size() != 0) {
+          table = table
+            .addHeader("WATERMARK")
+            .addRows(s"value -> ${event.progress.eventTime.get("watermark")}")
+            .addRows(s"numRowsDroppedByWatermark -> " +
+              s"${event.progress.stateOperators.map(_.numRowsDroppedByWatermark).sum}")
+        }
+
+        // Print the number of rows in state
+        if (event.progress.stateOperators.length != 0) {
+          table = table
+            .addHeader("STATE")
+            .addRows(s"numRowsTotal -> " +
+              s"${event.progress.stateOperators.map(_.numRowsTotal).sum}")
+        }
+
+        table.print()
+
+        messagesPerEpoch.synchronized {
+          messagesPerEpoch(queryId).remove(event.progress.batchId)
+        }
+      }
+      override def onQueryTerminated(event: StreamingQueryListener.QueryTerminatedEvent): Unit = {
+        println("From Spy query terminated!")
+        activeQueryIds.synchronized {
+            activeQueryIds -= queryId
+        }
+      }
+    })
+  }
+
+  private def registerMessages(
+      queryId: String,
+      epochId: Long,
+      messages: Array[InternalRow]): Unit = {
+    messagesPerEpoch.synchronized {
+      val messageMap = messagesPerEpoch.getOrElseUpdate(queryId,
+        scala.collection.mutable.Map[Long, Array[InternalRow]]())
+      messageMap(epochId) = messages
+    }
+  }
+
   println("SpyWriter object created!")
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/SpySink.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/SpySink.scala
@@ -1,0 +1,5 @@
+package org.apache.spark.sql.execution.streaming
+
+class SpySink {
+
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/DebugSink.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/DebugSink.scala
@@ -1,0 +1,5 @@
+package org.apache.spark.sql.execution.streaming.sources
+
+class DebugSink {
+
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/DebugSink.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/DebugSink.scala
@@ -1,5 +1,0 @@
-package org.apache.spark.sql.execution.streaming.sources
-
-class DebugSink {
-
-}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/MemorySource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/MemorySource.scala
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.streaming.sources
+
+import java.util
+import org.apache.spark.network.util.JavaUtils
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.connector.catalog.{SupportsRead, Table, TableCapability, TableProvider}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.connector.read.{Scan, ScanBuilder}
+import org.apache.spark.sql.connector.read.streaming.{ContinuousStream, MicroBatchStream}
+import org.apache.spark.sql.execution.streaming.LongOffset
+import org.apache.spark.sql.execution.streaming.continuous.RateStreamContinuousStream
+import org.apache.spark.sql.execution.streaming.sources.MemorySourceProvider.NAME_OPTION
+import org.apache.spark.sql.internal.connector.SimpleTableProvider
+import org.apache.spark.sql.sources.DataSourceRegister
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+class MemorySourceProvider extends TableProvider with DataSourceRegister {
+
+  private var cachedTable: Table = null
+
+  override def shortName(): String = "memory"
+
+  // This is called when a user-specific schema is not present. However, a memory source
+  // can't infer its schema, since it's entirely up to the user. As a result, if inferSchema
+  // is called before getTable, we have to throw an error.
+  //
+  // Ideally, we should add an interface like RequiresSchema, but we can do that later.
+  override def inferSchema(options: CaseInsensitiveStringMap)
+      : StructType = {
+    if (cachedTable == null) {
+      throw new IllegalStateException("Schema must be provided to memory source: " +
+        "it cannot be inferred.")
+    }
+
+    import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+    cachedTable.columns().asSchema
+  }
+
+  /**
+   * Return a {@link Table} instance with the specified table schema, partitioning and properties
+   * to do read/write. The returned table should report the same schema and partitioning with the
+   * specified ones, or Spark may fail the operation.
+   *
+   * @param schema The specified table schema.
+   * @param partitioning The specified table partitioning.
+   * @param properties The specified table properties. It's case preserving (contains exactly what
+   *                   users specified) and implementations are free to use it case sensitively or
+   *                   insensitively. It should be able to identify a table, e.g. file path, Kafka
+   *                   topic name, etc.
+   */
+  override def getTable(
+      schema: StructType,
+      partitioning: Array[Transform],
+      properties: util.Map[String, String])
+      : Table = {
+    // Create a MemorySourceTable with the given schema and name
+    val namespace = properties.get(NAME_OPTION)
+    if (namespace == null) {
+      throw new IllegalArgumentException(s"Table name is not specified in options.")
+    }
+
+    cachedTable = new MemorySourceTable(namespace, schema)
+    cachedTable
+  }
+}
+
+class MemorySourceTable(namespace: String, schema: StructType)
+  extends Table with SupportsRead {
+
+  override def name(): String = {
+    s"MemorySource(namespace=$namespace)"
+  }
+
+  override def capabilities(): util.Set[TableCapability] = {
+    util.EnumSet.of(TableCapability.MICRO_BATCH_READ)
+  }
+
+  override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = () => new Scan {
+    override def readSchema(): StructType = schema
+
+    override def toMicroBatchStream(checkpointLocation: String): MicroBatchStream =
+      new MemorySourceMicroBatchStream(namespace, schema)
+
+    override def columnarSupportMode(): Scan.ColumnarSupportMode =
+      Scan.ColumnarSupportMode.UNSUPPORTED
+  }
+}
+
+class MemorySourceMicroBatchStream(namespace: String, schema: StructType) extends MicroBatchStream {
+  override def latestOffset(): LongOffset = {
+    MemorySourceOffset(Map(str -> 0L))
+  }
+
+  override def planInputPartitions(start: Offset, end: Offset): Array[InputPartition] = {
+    val startOffset = start.asInstanceOf[MemorySourceOffset].partitionToValue(str)
+    val endOffset = end.asInstanceOf[MemorySourceOffset].partitionToValue(str)
+    assert(startOffset <= endOffset)
+    Array(MemoryInputPartition(startOffset, endOffset))
+  }
+
+  override def createReaderFactory(): PartitionReaderFactory = {
+    MemoryPartitionReaderFactory
+  }
+
+  override def commit(end: Offset): Unit = {}
+  override def stop(): Unit = {}
+}
+
+
+
+
+object MemorySourceProvider {
+  val NAME_OPTION = "name"
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
@@ -350,8 +350,11 @@ abstract class BaseSessionStateBuilder(
   /**
    * Interface to start and stop streaming queries.
    */
-  protected def streamingQueryManager: StreamingQueryManager =
+  protected def streamingQueryManager: StreamingQueryManager = {
+    // scalastyle:off
+    println("this spark session is " + this.toString)
     new StreamingQueryManager(session, conf)
+  }
 
   /**
    * An interface to register custom [[org.apache.spark.sql.util.QueryExecutionListener]]s

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
@@ -156,6 +156,8 @@ final class DataStreamReader private[sql](sparkSession: SparkSession) extends Lo
       extraOptions + ("path" -> path.get)
     }
 
+    // TODO(neil): If using the memory source, register the schema with the singleton
+
     val ds = DataSource.lookupDataSource(source, sparkSession.sessionState.conf).
       getConstructor().newInstance()
     // We need to generate the V1 data source so we can pass it to the V2 relation as a shim.

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
@@ -37,6 +37,7 @@ import org.apache.spark.sql.execution.datasources.json.JsonUtils.checkJsonSchema
 import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Utils, FileDataSourceV2}
 import org.apache.spark.sql.execution.datasources.xml.XmlUtils.checkXmlSchema
 import org.apache.spark.sql.execution.streaming.StreamingRelation
+import org.apache.spark.sql.execution.streaming.sources.{MemorySource, MemorySourceProvider}
 import org.apache.spark.sql.sources.StreamSourceProvider
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
@@ -156,7 +157,23 @@ final class DataStreamReader private[sql](sparkSession: SparkSession) extends Lo
       extraOptions + ("path" -> path.get)
     }
 
-    // TODO(neil): If using the memory source, register the schema with the singleton
+    if (source == MemorySourceProvider.SHORT_NAME) {
+      val namespaceOpt = optionsWithPath.get(MemorySourceProvider.NAME_OPTION)
+
+      val namespace = namespaceOpt match {
+        case Some(name) => name
+        case None => throw new RuntimeException(
+            s"Must specify option ${MemorySourceProvider.NAME_OPTION} " +
+              s"with ${MemorySourceProvider.SHORT_NAME} source")
+      }
+
+      if (userSpecifiedSchema.isEmpty) {
+        throw new RuntimeException(s"Must have schema when using " +
+          s"${MemorySourceProvider.SHORT_NAME} source")
+      }
+
+      MemorySource.registerNamespace(namespace, userSpecifiedSchema.get)
+    }
 
     val ds = DataSource.lookupDataSource(source, sparkSession.sessionState.conf).
       getConstructor().newInstance()

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
@@ -557,10 +557,11 @@ object DataStreamWriter {
   val SOURCE_NAME_FOREACH = "foreach"
   val SOURCE_NAME_FOREACH_BATCH = "foreachBatch"
   val SOURCE_NAME_CONSOLE = "console"
+  val SOURCE_NAME_SPY = "spy"
   val SOURCE_NAME_TABLE = "table"
   val SOURCE_NAME_NOOP = "noop"
 
   // these writer sources are also used for one-time query, hence allow temp checkpoint location
   val SOURCES_ALLOW_ONE_TIME_QUERY = Seq(SOURCE_NAME_MEMORY, SOURCE_NAME_FOREACH,
-    SOURCE_NAME_FOREACH_BATCH, SOURCE_NAME_CONSOLE, SOURCE_NAME_NOOP)
+    SOURCE_NAME_FOREACH_BATCH, SOURCE_NAME_CONSOLE, SOURCE_NAME_SPY, SOURCE_NAME_NOOP)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryManager.scala
@@ -50,6 +50,8 @@ class StreamingQueryManager private[sql] (
 
   private[sql] val stateStoreCoordinator =
     StateStoreCoordinatorRef.forDriver(sparkSession.sparkContext.env)
+  // scalastyle:off
+  println("Created a new listener bus")
   private val listenerBus =
     new StreamingQueryListenerBus(Some(sparkSession.sparkContext.listenerBus))
 
@@ -228,6 +230,8 @@ class StreamingQueryManager private[sql] (
 
   /** Post a listener event */
   private[sql] def postListenerEvent(event: StreamingQueryListener.Event): Unit = {
+    // scalastyle:off
+    println("Got event: " + event.toString)
     listenerBus.post(event)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/MemorySourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/MemorySourceSuite.scala
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.streaming.sources
+
+import org.apache.spark.sql.streaming.StreamTest
+import org.apache.spark.sql.types.{LongType, StructType}
+
+class MemorySourceSuite extends StreamTest {
+  test("hello world") {
+    val schema = new StructType().add("first", LongType).add("second", LongType)
+
+    val source = spark.readStream.format("memory").option("name", "neil").schema(schema).load()
+
+    val df = source.select("*")
+
+    val query = df.writeStream.format("memory").queryName("neil").start()
+
+    MemorySource.addData("neil", (1, 2))
+    query.processAllAvailable()
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/MemorySourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/MemorySourceSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.streaming.StreamTest
 import org.apache.spark.sql.types.{LongType, StructType}
 
 class MemorySourceSuite extends StreamTest {
-  test("hello world") {
+  test("basic test") {
     val schema = new StructType().add("first", LongType).add("second", LongType)
 
     val source = spark.readStream.format("memory").option("name", "neil").schema(schema).load()
@@ -30,7 +30,7 @@ class MemorySourceSuite extends StreamTest {
 
     val query = df.writeStream.format("memory").queryName("neil").start()
 
-    MemorySource.addData("neil", (1, 2))
+    MemorySource.addData("neil", Seq(1, 2))
     query.processAllAvailable()
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/MemorySourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/MemorySourceSuite.scala
@@ -28,9 +28,16 @@ class MemorySourceSuite extends StreamTest {
 
     val df = source.select("*")
 
-    val query = df.writeStream.format("memory").queryName("neil").start()
+    val query = df.writeStream.format("console").queryName("neil").start()
 
-    MemorySource.addData("neil", Seq(1, 2))
+    MemorySource.addData("neil", Seq(1L, 2L))
     query.processAllAvailable()
+
+    // scalastyle:off
+    println(query.lastProgress)
+
+    MemorySource.addData("neil", Seq(1L, "asdf"))
+    query.processAllAvailable()
+    println(query.lastProgress)
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
