### PR TITLE
[WIP] Initial test to determine if default values are being dropped from from_protobuf

### DIFF
--- a/connector/protobuf/src/test/resources/protobuf/functions_suite.proto
+++ b/connector/protobuf/src/test/resources/protobuf/functions_suite.proto
@@ -129,6 +129,10 @@ message OtherExample {
   string other = 1;
 }
 
+message LongExample {
+  int64 key = 1;
+}
+
 message IncludedExample {
   string included = 1;
   OtherExample other = 2;
@@ -321,10 +325,10 @@ message Proto3AllTypes {
   NestedEnum enum_val = 3;
   OtherExample message = 4;
 
-  optional int64 optional_int = 5;
-  optional string optional_text = 6;
-  optional NestedEnum optional_enum_val = 7;
-  optional OtherExample optional_message = 8;
+  int64 optional_int = 5;
+  string optional_text = 6;
+  NestedEnum optional_enum_val = 7;
+  OtherExample optional_message = 8;
 
   repeated int64 repeated_num = 9;
   repeated OtherExample repeated_message = 10;

--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
@@ -18,12 +18,14 @@ package org.apache.spark.sql.protobuf
 
 import java.sql.Timestamp
 import java.time.Duration
+
 import scala.jdk.CollectionConverters._
-import com.google.protobuf.{BoolValue, ByteString, BytesValue, DoubleValue, DynamicMessage, FloatValue, Int32Value, Int64Value, StringValue, UInt32Value, UInt64Value, Any => AnyProto}
+
+import com.google.protobuf.{Any => AnyProto, BoolValue, ByteString, BytesValue, DoubleValue, DynamicMessage, FloatValue, Int32Value, Int64Value, StringValue, UInt32Value, UInt64Value}
 import org.json4s.jackson.JsonMethods
+
 import org.apache.spark.sql.{AnalysisException, Column, DataFrame, QueryTest, Row}
 import org.apache.spark.sql.functions.{array, lit, map, struct, typedLit}
-import org.apache.spark.sql.protobuf.functions.from_protobuf
 import org.apache.spark.sql.protobuf.protos.Proto2Messages.Proto2AllTypes
 import org.apache.spark.sql.protobuf.protos.SimpleMessageProtos._
 import org.apache.spark.sql.protobuf.protos.SimpleMessageProtos.SimpleMessageRepeated.NestedEnum


### PR DESCRIPTION
### What changes were proposed in this pull request?

N/A.

### Why are the changes needed?

Investigating a potential case of dropping data when a record's field is the default value for that datatype, when using `from_protobuf`.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
