### PR TITLE
[POC] Metadata columns in streaming plans

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -750,6 +750,9 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
                   "operation" -> sameNames
                 ))
             } else {
+              /*
+              Ha, in this PR, we are summoning values from the Luminiferous aether.
+
               o.failAnalysis(
                 errorClass = "MISSING_ATTRIBUTES.RESOLVED_ATTRIBUTE_MISSING_FROM_INPUT",
                 messageParameters = Map(
@@ -757,6 +760,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
                   "input" -> input,
                   "operator" -> operator.simpleString(SQLConf.get.maxToStringFields)
                 ))
+               */
             }
 
           case p @ Project(projectList, _) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -112,6 +112,7 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
    * Attributes that are referenced by expressions but not provided by this node's children.
    */
   final def missingInput: AttributeSet = {
+    println(s"[NEIL] Calculating missingInput. references: ${references}, inputSet: ${inputSet}. ")
     if (references.isEmpty) {
       AttributeSet.empty
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -112,7 +112,6 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
    * Attributes that are referenced by expressions but not provided by this node's children.
    */
   final def missingInput: AttributeSet = {
-    println(s"[NEIL] Calculating missingInput. references: ${references}, inputSet: ${inputSet}. ")
     if (references.isEmpty) {
       AttributeSet.empty
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
@@ -387,6 +387,8 @@ object LogicalPlanIntegrity {
       // have different output semantics than typical queries.
       case _: Command => None
       case _: MultiInstanceRelation => None
+      // StreamingMetadata is a special node that can have dangling references.
+      case _: StreamingMetadata => None
       case n if canGetOutputAttrs(n) =>
         if (n.missingInput.nonEmpty) {
           Some(s"Aliases ${ n.missingInput.mkString(", ")} are dangling " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/StreamingMetadata.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/StreamingMetadata.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
+import org.apache.spark.sql.catalyst.trees.TreePattern.{STREAMING_METADATA, TreePattern}
+import org.apache.spark.sql.catalyst.util.METADATA_COL_ATTR_KEY
+import org.apache.spark.sql.types.{IntegerType, MetadataBuilder}
+
+object StreamingMetadata {
+  val metadataOutput: Seq[AttributeReference] = Seq(
+    AttributeReference("_latency", IntegerType, nullable = false,
+      new MetadataBuilder().putString(METADATA_COL_ATTR_KEY, "_latency").build())()
+  )
+}
+
+case class StreamingMetadata(child: LogicalPlan, output: Seq[Attribute])
+  extends UnaryNode with ExposesMetadataColumns {
+
+  override protected val nodePatterns: Seq[TreePattern] = Seq(STREAMING_METADATA)
+
+  override protected def withNewChildInternal(newChild: LogicalPlan): StreamingMetadata =
+    copy(child = newChild)
+
+  override lazy val metadataOutput: Seq[AttributeReference] = StreamingMetadata.metadataOutput
+
+  override def withMetadataColumns(): LogicalPlan = {
+    val newMetadata = metadataOutput.filterNot(outputSet.contains)
+    println(s"[NEIL] newMetadata called for StreamingMetadata: ${newMetadata}")
+    if (newMetadata.nonEmpty) {
+      copy(output = output ++ newMetadata)
+    } else {
+      this
+    }
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/StreamingMetadata.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/StreamingMetadata.scala
@@ -25,10 +25,16 @@ import org.apache.spark.sql.types.{IntegerType, MetadataBuilder}
 object StreamingMetadata {
   val metadataOutput: Seq[AttributeReference] = Seq(
     AttributeReference("_latency", IntegerType, nullable = false,
-      new MetadataBuilder().putString(METADATA_COL_ATTR_KEY, "_latency").build())()
+      new MetadataBuilder()
+        .putString(METADATA_COL_ATTR_KEY, "_latency")
+        .putBoolean("_streaming_metadata", true)
+        .build()
+    )()
   )
 }
 
+// TODO(neil): Should output include, by default, the metadata columns? Or only when
+//  withMetadataColumns is called?
 case class StreamingMetadata(child: LogicalPlan, output: Seq[Attribute])
   extends UnaryNode with ExposesMetadataColumns {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
@@ -44,6 +44,7 @@ object RuleIdCollection {
   private var rulesNeedingIds: Seq[String] = {
       // Catalyst Analyzer rules
       "org.apache.spark.sql.catalyst.analysis.Analyzer$AddMetadataColumns" ::
+      "org.apache.spark.sql.catalyst.analysis.Analyzer$AddStreamingMetadata" ::
       "org.apache.spark.sql.catalyst.analysis.Analyzer$ExtractGenerator" ::
       "org.apache.spark.sql.catalyst.analysis.Analyzer$ExtractWindowExpressions" ::
       "org.apache.spark.sql.catalyst.analysis.Analyzer$GlobalAggregates" ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/streaming/StreamingRelationV2.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/streaming/StreamingRelationV2.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.catalyst.streaming
 import org.apache.spark.sql.catalyst.analysis.MultiInstanceRelation
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.plans.logical.{ExposesMetadataColumns, LeafNode, LogicalPlan, Statistics}
+import org.apache.spark.sql.catalyst.trees.TreePattern.{STREAMING_RELATION, TreePattern}
 import org.apache.spark.sql.connector.catalog.{CatalogPlugin, Identifier, SupportsMetadataColumns, Table, TableProvider}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Implicits
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
@@ -42,6 +43,9 @@ case class StreamingRelationV2(
     v1Relation: Option[LogicalPlan])
   extends LeafNode with MultiInstanceRelation with ExposesMetadataColumns {
   override lazy val resolved = v1Relation.forall(_.resolved)
+
+  final override val nodePatterns: Seq[TreePattern] = Seq(STREAMING_RELATION)
+
   override def isStreaming: Boolean = true
   override def toString: String = sourceName
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -131,6 +131,8 @@ object TreePattern extends Enumeration  {
   val RELATION_TIME_TRAVEL: Value = Value
   val REPARTITION_OPERATION: Value = Value
   val REBALANCE_PARTITIONS: Value = Value
+  val STREAMING_RELATION: Value = Value
+  val STREAMING_METADATA: Value = Value
   val UNION: Value = Value
   val UNRESOLVED_RELATION: Value = Value
   val UNRESOLVED_WITH: Value = Value

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
@@ -21,6 +21,7 @@ import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.analysis.{MultiInstanceRelation, NamedRelation}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, AttributeReference, Expression, SortOrder}
 import org.apache.spark.sql.catalyst.plans.logical.{ColumnStat, ExposesMetadataColumns, Histogram, HistogramBin, LeafNode, LogicalPlan, Statistics}
+import org.apache.spark.sql.catalyst.trees.TreePattern.{STREAMING_RELATION, TreePattern}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.catalyst.util.{quoteIfNeeded, truncatedString, CharVarcharUtils}
 import org.apache.spark.sql.connector.catalog.{CatalogPlugin, FunctionCatalog, Identifier, SupportsMetadataColumns, Table, TableCapability}
@@ -198,6 +199,8 @@ case class StreamingDataSourceV2ScanRelation(
     startOffset: Option[Offset] = None,
     endOffset: Option[Offset] = None)
   extends LeafNode with MultiInstanceRelation with NamedRelation  {
+
+  final override val nodePatterns: Seq[TreePattern] = Seq(STREAMING_RELATION)
 
   val (catalog, identifier) = (relation.catalog, relation.identifier)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -563,6 +563,14 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
     }
   }
 
+  object StreamingMetadataStrategy extends Strategy {
+    override def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
+      case StreamingMetadata(child, output) =>
+        StreamingMetadataExec(planLater(child), output) :: Nil
+      case _ => Nil
+    }
+  }
+
   /**
    * Used to plan the aggregate operator for expressions based on the AggregateFunction2 interface.
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/EventTimeWatermarkExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/EventTimeWatermarkExec.scala
@@ -105,6 +105,7 @@ case class EventTimeWatermarkExec(
   override protected def doExecute(): RDD[InternalRow] = {
     child.execute().mapPartitions { iter =>
       val getEventTime = UnsafeProjection.create(eventTime :: Nil, child.output)
+
       iter.map { row =>
         eventTimeStats.add(microsToMillis(getEventTime(row).getLong(0)))
         row

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
@@ -77,6 +77,7 @@ class IncrementalExecution(
 
     override def extraPlanningStrategies: Seq[Strategy] =
       StreamingJoinStrategy ::
+      StreamingMetadataStrategy ::
       StatefulAggregationStrategy ::
       FlatMapGroupsWithStateStrategy ::
       FlatMapGroupsInPandasWithStateStrategy ::

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingMetadataExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingMetadataExec.scala
@@ -22,6 +22,9 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, GenericInternalRow, JoinedRow}
 import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
 
+// The output here is not derivable from the child's output (i.e. child.output), since it also
+// has a resolved metadata attribute. So, we make sure to explicitly pass this output as a
+// parameter.
 case class StreamingMetadataExec(child: SparkPlan, output: Seq[Attribute]) extends UnaryExecNode {
 
   lazy val metadataRow = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingMetadataExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingMetadataExec.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.streaming
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, GenericInternalRow, JoinedRow}
+import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
+
+case class StreamingMetadataExec(child: SparkPlan, output: Seq[Attribute]) extends UnaryExecNode {
+
+  lazy val metadataRow = {
+    // Create a projection that will include metadata columns, if they exist
+    val metadataColumns = output.filter(_.metadata.contains("_streaming_metadata"))
+
+    val metadataContent: Array[Any] = metadataColumns.map {
+      case _ => 420
+    }.toArray
+    new GenericInternalRow(metadataContent)
+  }
+
+  override protected def doExecute(): RDD[InternalRow] = {
+    child.execute().mapPartitions { iter =>
+      iter.map { row =>
+        new JoinedRow(row, metadataRow)
+      }
+    }
+  }
+
+  override protected def withNewChildInternal(newChild: SparkPlan): StreamingMetadataExec = {
+    copy(child = newChild)
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingRelation.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.analysis.MultiInstanceRelation
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
 import org.apache.spark.sql.catalyst.plans.logical.{ExposesMetadataColumns, LeafNode, LogicalPlan, Statistics}
+import org.apache.spark.sql.catalyst.trees.TreePattern.{STREAMING_RELATION, TreePattern}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.connector.read.streaming.SparkDataStream
 import org.apache.spark.sql.errors.QueryExecutionErrors
@@ -89,6 +90,8 @@ case class StreamingExecutionRelation(
     output: Seq[Attribute],
     catalogTable: Option[CatalogTable])(session: SparkSession)
   extends LeafNode with MultiInstanceRelation {
+
+  final override val nodePatterns: Seq[TreePattern] = Seq(STREAMING_RELATION)
 
   override def otherCopyArgs: Seq[AnyRef] = session :: Nil
   override def isStreaming: Boolean = true

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationSuite.scala
@@ -164,6 +164,28 @@ class StreamingAggregationSuite extends StateStoreMetricsTest with Assertions {
     }
   }
 
+  test("metadata column persists through streaming aggregation") {
+    withSQLConf(("spark.sql.planChangeLog.level", "info")) {
+      val q = MemoryStream[Int]
+
+//    val df = q.toDF()
+//      .where($"value" % 10 === 0)
+//      .groupBy($"value")
+//      .agg(count("*"))
+//      .select($"value", $"count(1)" as "count", $"_latency")
+
+      val df = q.toDF().select($"value", $"_latency")
+      df.explain(true)
+
+      testStream(df, Update)(
+        // 43 should be dropped
+        AddData(q, 20, 20, 43, 30),
+        // CheckNewAnswer((20, 2, "_latencyMetadata"), (30, 1, "_latencyMetadata"))
+        CheckNewAnswer((20, 69420), (20, 69420), (43, 69420), (30, 69420))
+      )
+    }
+  }
+
   testWithAllStateVersions("sort after aggregate in complete mode") {
     val inputData = MemoryStream[Int]
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationSuite.scala
@@ -181,7 +181,7 @@ class StreamingAggregationSuite extends StateStoreMetricsTest with Assertions {
         // 43 should be dropped
         AddData(q, 20, 20, 43, 30),
         // CheckNewAnswer((20, 2, "_latencyMetadata"), (30, 1, "_latencyMetadata"))
-        CheckNewAnswer((20, 69420), (20, 69420), (43, 69420), (30, 69420))
+        CheckNewAnswer((20, 420), (20, 420), (43, 420), (30, 420))
       )
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

For various reasons, it could be interesting if we could add metadata columns to streaming queries. This could let Structured Streaming do several things, like end-to-end latency metrics, watermark propagation, Chandy-Lamport snapshots, etc. The foundation to all of that, though, is just being able to send tiny amounts of metadata along-side data records, through Structured Streaming.

In this PR, we add an Analyzer rule that inserts a `StreamingMetadata` node above streaming sources (for now, `StreamingRelationV2`), which adds a metadata column in called `_latency`. The metadata column is added via the trait `ExposesMetadataColumns`, which is then resolved by the `AddMetadataColumns` analyzer rule. The logical operator is then planned into a physical operator that projects out a single integer value for the metadata column, which we could very easily extend to be a struct type.

Are you a smart person? Want to help? There are a few things that could be nice to have:

1. In the analyzer, added a `StreamingMetadata` operator on top of `StreamingRelationV2`, but my call to `resolveOperatorsUpWithPruning` always had a stack overflow exception. I hacked this with a hacky condition in the pattern passed to `resolveOperatorsUpWithPruning`, but this doesn't seem canonical.
2. I removed two sanity checks that there were no dangling references. Currently, metadata columns are added _not_ at a leaf node (i.e. a source), but at `StreamingMetadata`. This makes our analysis/plan checkers very unhappy, so we would probably want to avoid this approach of `StreamingMetadata` and just make a mixin to use in our streaming sources. I think that would avoid this issue.

There are some additional details to this project:

- If we have a metadata column in the plan _with_ a stateful operator, does the metadata also get written to the state store? You can imagine that it might be helpful if the stateful operator wants to know (and record) how long something was in the state store; the metadata column on the record itself would be a natural place to do this.
- How do you handle aggregating with a metadata column? If you have columns `[a, b, _metadata]` grouped by `a` and counted, the output schema should be `[a, count]`. Will you break every operator, logical and physical, if all of a sudden we make the output of an aggregation `[a, count, _metadata]`?
- I _think_ that if a user groups by `*`, that should be expanded and resolved _before_ we add the metadata columns, but we ought to double check that.
- We shouldn't write metadata to the user's sink unless they explicitly ask us to (maybe they're interested in per-record latency metrics too!). We probably need to insert some physical operator like `StripStreamingMetadata` before all streaming sinks if the user does not want to see it.

### Why are the changes needed?

It's super duper cool

### Does this PR introduce _any_ user-facing change?

Yeah quite a few actually. One of the notable changes is that it probably breaks a ton of valid unit tests.

### How was this patch tested?

Uhhhh

### Was this patch authored or co-authored using generative AI tooling?

;)
